### PR TITLE
Instantiate

### DIFF
--- a/app/scripts/query.js
+++ b/app/scripts/query.js
@@ -1,42 +1,46 @@
+'use strict';
+
+var regexTerm    = /([\w\+\-&\|!\(\){}\[\]\^"~\*\?:\\]+)/g;
+var regexNonTerm = /[^\w\+\-&\|!\(\){}\[\]\^"~\*\?:\\]+/g;
+
+var enumGlueTypes = {
+    or: 1,
+    and: 2,
+    phrase: 3,
+    not: 4
+};
+
+var glue = function (term, type, field) {
+    var rv = '';
+
+    switch (type) {
+    case enumGlueTypes.or:
+        rv += term.replace(regexTerm, field + ':$1');
+        rv = rv.replace(regexNonTerm, ' OR ');
+        break;
+    case enumGlueTypes.and:
+        rv += term.replace(regexTerm, field + ':$1');
+        rv = rv.replace(regexNonTerm, ' AND ');
+        break;
+    case enumGlueTypes.phrase:
+        rv += field + ':"' + term + '"';
+        break;
+    case enumGlueTypes.not:
+        rv += term.replace(regexTerm, '-' + field + ':$1');
+        rv = rv.replace(regexNonTerm, ' AND ');
+        break;
+    }
+
+    return rv;
+};
+
 var Query = function () {
-    'use strict';
+
+    if (!(this instanceof Query)) {
+        return new Query();
+    }
+
     var queryExpressions = [];
-
-    var regexTerm    = /([\w\+\-&\|!\(\){}\[\]\^"~\*\?:\\]+)/g;
-    var regexNonTerm = /[^\w\+\-&\|!\(\){}\[\]\^"~\*\?:\\]+/g;
-
-    var glue = function (term, type, field) {
-        var rv = '';
-
-        switch (type) {
-        case enumGlueTypes.or:
-            rv += term.replace(regexTerm, field + ':$1');
-            rv = rv.replace(regexNonTerm, ' OR ');
-            break;
-        case enumGlueTypes.and:
-            rv += term.replace(regexTerm, field + ':$1');
-            rv = rv.replace(regexNonTerm, ' AND ');
-            break;
-        case enumGlueTypes.phrase:
-            rv += field + ':"' + term + '"';
-            break;
-        case enumGlueTypes.not:
-            rv += term.replace(regexTerm, '-' + field + ':$1');
-            rv = rv.replace(regexNonTerm, ' AND ');
-            break;
-        }
-
-        return rv;
-    };
-
-    var enumGlueTypes = {
-        or: 1,
-        and: 2,
-        phrase: 3,
-        not: 4
-    };
-
-    this.enumGlueTypes = enumGlueTypes;
 
     this.setQueryExpression = function (index, settings) {
         var defaults = { term: '*', field: 'er', glueType: enumGlueTypes.or, glueTypeNextTerm: enumGlueTypes.or };
@@ -82,5 +86,7 @@ var Query = function () {
         }, '');
     };
 };
+
+Query.prototype.enumGlueTypes = enumGlueTypes;
 
 module.exports = Query;

--- a/app/scripts/query.js
+++ b/app/scripts/query.js
@@ -42,8 +42,6 @@ var Query = function () {
 
     var queryExpressions = [];
 
-    this.enumGlueTypes = enumGlueTypes;
-
     this.setQueryExpression = function (index, settings) {
         var defaults = { term: '*', field: 'er', glueType: enumGlueTypes.or, glueTypeNextTerm: enumGlueTypes.or };
         settings = settings || defaults;
@@ -88,5 +86,7 @@ var Query = function () {
         }, '');
     };
 };
+
+Query.prototype.enumGlueTypes = enumGlueTypes;
 
 module.exports = Query;

--- a/app/scripts/query.js
+++ b/app/scripts/query.js
@@ -42,6 +42,8 @@ var Query = function () {
 
     var queryExpressions = [];
 
+    this.enumGlueTypes = enumGlueTypes;
+
     this.setQueryExpression = function (index, settings) {
         var defaults = { term: '*', field: 'er', glueType: enumGlueTypes.or, glueTypeNextTerm: enumGlueTypes.or };
         settings = settings || defaults;
@@ -86,7 +88,5 @@ var Query = function () {
         }, '');
     };
 };
-
-Query.prototype.enumGlueTypes = enumGlueTypes;
 
 module.exports = Query;

--- a/test/spec/test.jsx
+++ b/test/spec/test.jsx
@@ -36,6 +36,11 @@ var SearchBuilderAdd = require('../../app/scripts/SearchBuilderAdd.jsx');
         it('should expose deleteQueryExpression', function () {
             expect(query.deleteQueryExpression).toEqual(jasmine.any(Function));
         });
+        it('should instantiate with or without new operator', function () {
+            var otherQuery = Query();
+            expect(query instanceof Query).toBe(true);
+            expect(otherQuery instanceof Query).toBe(true);
+        });
 
         describe('getQueryString()', function () {
             it('should return an empty string initially', function () {


### PR DESCRIPTION
fix #46 

Allow query object to be created either with `new query()` or just `query()`
